### PR TITLE
preventing new subviews from being added every time the menu is opened.

### DIFF
--- a/REMenu/REMenu.h
+++ b/REMenu/REMenu.h
@@ -41,6 +41,7 @@
 //
 @property (strong, readwrite, nonatomic) NSArray *items;
 @property (assign, readonly, nonatomic) BOOL isOpen;
+@property (assign, readwrite, nonatomic) BOOL closeOnSelect;
 
 // Style
 //
@@ -76,6 +77,8 @@
 @property (strong, readwrite, nonatomic) UIColor *subtitleHighlightedTextShadowColor;
 @property (assign, readwrite, nonatomic) CGSize subtitleHighlightedTextShadowOffset;
 @property (assign, readwrite, nonatomic) NSTextAlignment subtitleTextAlignment;
+
+@property (strong, readwrite, nonatomic) void (^closeHandler)(REMenu *menu);
 
 
 - (id)initWithItems:(NSArray *)items;

--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -50,6 +50,7 @@
     _menuWrapperView.layer.rasterizationScale = [UIScreen mainScreen].scale;
     
     self.items = items;
+    self.closeOnSelect = YES;
     self.itemHeight = 48;
     self.separatorHeight = 2;
     
@@ -157,6 +158,7 @@
             _menuWrapperView.frame = frame;
         } completion:^(BOOL finished) {
             [_containerView removeFromSuperview];
+            if (_closeHandler) _closeHandler(self);
         }];
     }];
 }

--- a/REMenu/REMenuItemView.m
+++ b/REMenu/REMenuItemView.m
@@ -125,8 +125,11 @@
     _subtitleLabel.textColor = _menu.subtitleTextColor;
     _subtitleLabel.shadowColor = _menu.subtitleTextShadowColor;
     _subtitleLabel.shadowOffset = _menu.subtitleTextShadowOffset;
-    [_menu close];
-    
+
+    if (_menu.closeOnSelect) {
+        [_menu close];
+    }
+
     if (_item.action) {
         _item.action(_item);
     }


### PR DESCRIPTION
fixing menu so it doesnt re-add subviews every time you open it. The views piled on views was causing the text highlight color to not be restored after the second open.
