### PR TITLE
Fixed issue with calling [REMenu close] before a previous call has fully animated.

### DIFF
--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -180,7 +180,6 @@
 
 - (void)closeWithCompletion:(void (^)(void))completion
 {
-    _isOpen = NO;
     __typeof (&*self) __weak weakSelf = self;
     
     [UIView animateWithDuration:0.2 animations:^{
@@ -197,6 +196,7 @@
             [weakSelf.menuWrapperView removeFromSuperview];
             [weakSelf.backgroundButton removeFromSuperview];
             [weakSelf.containerView removeFromSuperview];
+            _isOpen = NO;
             if (completion)
                 completion();
         }];


### PR DESCRIPTION
Previously, if you tapped the close button twice, the second tap being before the menu fully closes, the animation breaks and the current view controller loses the ability to receive touch events.
