### PR TITLE
Let menu drop from and close to the window's top boarder. Refine layout to avoid constant margin. 

### DIFF
--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -194,7 +194,8 @@
     
     // Set up frames
     //
-    self.menuWrapperView.frame = CGRectMake(0, -self.combinedHeight, rect.size.width, self.combinedHeight + navigationBarOffset);
+    CGFloat wrapperHeight = self.combinedHeight + navigationBarOffset;
+    self.menuWrapperView.frame = CGRectMake(0, -wrapperHeight, rect.size.width, wrapperHeight);
     self.menuView.frame = self.menuWrapperView.bounds;
     self.containerView.frame = rect;
     self.backgroundButton.frame = self.containerView.bounds;
@@ -235,7 +236,7 @@
     void (^closeMenu)(void) = ^{
         [UIView animateWithDuration:self.animationDuration animations:^{
             CGRect frame = self.menuView.frame;
-            frame.origin.y = - self.combinedHeight;
+            frame.origin.y = - frame.size.height;
             self.menuWrapperView.frame = frame;
             self.backgroundView.alpha = 0;
         } completion:^(BOOL finished) {


### PR DESCRIPTION
This patch mainly to achieve better effect with iOS 7's translucent Navigation Bar. 
Instead of appearing directly behind the navigation bar and drop from that position, the menu now drops from the window's top boarder. So the drop down process can be seen through the Navigation Bar. 

![remenu](https://f.cloud.github.com/assets/510089/1147080/48fd1282-1e95-11e3-80be-f6cd5b29d07f.gif)

Tested in XCode 5 + SDK 7.0 with both iOS 7 and iOS 6.1 + iPhone and iPad simulator. Layout and rotate works fine as before. 
