### PR TITLE
avoid crash in case of no 'window' property in app delegate

### DIFF
--- a/REMenu/RECommonFunctions.m
+++ b/REMenu/RECommonFunctions.m
@@ -32,7 +32,8 @@ BOOL REUIKitIsFlatMode()
     dispatch_once(&onceToken, ^{
         if (floor(NSFoundationVersionNumber) > 993.0) {
             // If your app is running in legacy mode, tintColor will be nil - else it must be set to some color.
-            if (UIApplication.sharedApplication.keyWindow) {
+            if (UIApplication.sharedApplication.keyWindow &&
+                [UIApplication.sharedApplication.delegate respondsToSelector:@selector(window)]) {
                 isUIKitFlatMode = [UIApplication.sharedApplication.delegate.window performSelector:@selector(tintColor)] != nil;
             } else {
                 // Possible that we're called early on (e.g. when used in a Storyboard). Adapt and use a temporary window.


### PR DESCRIPTION
this change was dropped at commit 9967d35635e60e256faf3aa6e78a2ef826d8ad89 
