### PR TITLE
Solved a crash building on iOS 7 and launching the app in iOS 6 devices

### DIFF
--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -235,27 +235,42 @@
     if (self.bounce)
     {
         self.isAnimating = YES;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_7_0
-        [UIView animateWithDuration:self.animationDuration+self.bounceAnimationDuration
-                              delay:0.0
-             usingSpringWithDamping:0.6
-              initialSpringVelocity:4.0
-#else
-        [UIView animateWithDuration:self.animationDuration
-                              delay:0.0
-#endif
-                            options:UIViewAnimationOptionBeginFromCurrentState|UIViewAnimationOptionCurveEaseInOut
-                         animations:^
-        {
-            self.backgroundView.alpha = 1.0;
-            CGRect frame = self.menuView.frame;
-            frame.origin.y = -40.0 - self.separatorHeight;
-            self.menuWrapperView.frame = frame;
+
+        if ([UIView respondsToSelector:@selector(animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:)]) {
+            [UIView animateWithDuration:self.animationDuration+self.bounceAnimationDuration
+                                  delay:0.0
+                 usingSpringWithDamping:0.6
+                  initialSpringVelocity:4.0
+                                options:UIViewAnimationOptionBeginFromCurrentState|UIViewAnimationOptionCurveEaseInOut
+                             animations:^
+             {
+                 self.backgroundView.alpha = 1.0;
+                 CGRect frame = self.menuView.frame;
+                 frame.origin.y = -40.0 - self.separatorHeight;
+                 self.menuWrapperView.frame = frame;
+             }
+                             completion:^(BOOL finished)
+             {
+                 self.isAnimating = NO;
+             }];
+
+        } else {
+            [UIView animateWithDuration:self.animationDuration
+                                  delay:0.0
+                                options:UIViewAnimationOptionBeginFromCurrentState|UIViewAnimationOptionCurveEaseInOut
+                             animations:^
+             {
+                 self.backgroundView.alpha = 1.0;
+                 CGRect frame = self.menuView.frame;
+                 frame.origin.y = -40.0 - self.separatorHeight;
+                 self.menuWrapperView.frame = frame;
+             }
+                             completion:^(BOOL finished)
+             {
+                 self.isAnimating = NO;
+             }];
+
         }
-        completion:^(BOOL finished)
-        {
-            self.isAnimating = NO;
-        }];
     }
     else
     {


### PR DESCRIPTION
Hi Roman! 

I've found this problem today. The app crashes if you build on >iOS 7 and execute on iOS 6  I've just gone to the easiest solution, just checking if the selector exists but feel free to merge it or solve it your way 
