### PR TITLE
Changed order of title assignment in example view controllers `-[viewDidLoad]`.

### DIFF
--- a/REMenuExample/REMenuExample/Classes/Controllers/ActivityViewController.m
+++ b/REMenuExample/REMenuExample/Classes/Controllers/ActivityViewController.m
@@ -16,8 +16,8 @@
 
 - (void)viewDidLoad
 {
-    [super viewDidLoad];
     self.title = @"Activity";
+    [super viewDidLoad];
 }
 
 @end

--- a/REMenuExample/REMenuExample/Classes/Controllers/ExploreViewController.m
+++ b/REMenuExample/REMenuExample/Classes/Controllers/ExploreViewController.m
@@ -16,8 +16,8 @@
 
 - (void)viewDidLoad
 {
-    [super viewDidLoad];
     self.title = @"Explore";
+    [super viewDidLoad];
 }
 
 @end

--- a/REMenuExample/REMenuExample/Classes/Controllers/HomeViewController.m
+++ b/REMenuExample/REMenuExample/Classes/Controllers/HomeViewController.m
@@ -16,8 +16,8 @@
 
 - (void)viewDidLoad
 {
-    [super viewDidLoad];
     self.title = @"Home";
+    [super viewDidLoad];
 }
 
 @end

--- a/REMenuExample/REMenuExample/Classes/Controllers/ProfileViewController.m
+++ b/REMenuExample/REMenuExample/Classes/Controllers/ProfileViewController.m
@@ -16,8 +16,8 @@
 
 - (void)viewDidLoad
 {
-    [super viewDidLoad];
     self.title = @"Profile";
+    [super viewDidLoad];
 }
 
 @end


### PR DESCRIPTION
This way the title is correct when we go into the "view did load" stage, and it's easier to get the correct title if we are using the REMenu from a title view/button.
