### PR TITLE
implemented separator offset

### DIFF
--- a/REMenu/REMenu.h
+++ b/REMenu/REMenu.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSInteger, REMenuLiveBackgroundStyle) {
 @property (strong, readwrite, nonatomic) UIColor *backgroundColor;
 @property (strong, readwrite, nonatomic) UIColor *separatorColor;
 @property (assign, readwrite, nonatomic) CGFloat separatorHeight;
+@property (assign, readwrite, nonatomic) CGSize separatorOffset;
 @property (strong, readwrite, nonatomic) UIFont *font;
 @property (strong, readwrite, nonatomic) UIColor *textColor;
 @property (strong, readwrite, nonatomic) UIColor *textShadowColor;

--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -57,6 +57,7 @@
         _closeOnSelection = YES;
         _itemHeight = 48.0;
         _separatorHeight = 2.0;
+        _separatorOffset = CGSizeMake(0.0, 0.0);
         _waitUntilAnimationIsComplete = YES;
         
         _textOffset = CGSizeMake(0, 0);
@@ -193,9 +194,9 @@
         if (index == self.items.count - 1)
             itemHeight += self.cornerRadius;
         
-        UIView *separatorView = [[UIView alloc] initWithFrame:CGRectMake(0,
-                                                                         index * self.itemHeight + index * self.separatorHeight + 40.0 + navigationBarOffset,
-                                                                         rect.size.width,
+        UIView *separatorView = [[UIView alloc] initWithFrame:CGRectMake(self.separatorOffset.width,
+                                                                         index * self.itemHeight + index * self.separatorHeight + 40.0 + navigationBarOffset + self.separatorOffset.height,
+                                                                         rect.size.width - self.separatorOffset.width,
                                                                          self.separatorHeight)];
         separatorView.backgroundColor = self.separatorColor;
         separatorView.autoresizingMask = UIViewAutoresizingFlexibleWidth;

--- a/REMenuExample/REMenuExample/Classes/Controllers/NavigationViewController.m
+++ b/REMenuExample/REMenuExample/Classes/Controllers/NavigationViewController.m
@@ -115,7 +115,8 @@
     //
     //self.menu.liveBlur = YES;
     //self.menu.liveBlurBackgroundStyle = REMenuLiveBackgroundStyleDark;
-    
+
+    self.menu.separatorOffset = CGSizeMake(15.0, 0.0);
     self.menu.imageOffset = CGSizeMake(5, -1);
     self.menu.waitUntilAnimationIsComplete = NO;
     self.menu.badgeLabelConfigurationBlock = ^(UILabel *badgeLabel, REMenuItem *item) {


### PR DESCRIPTION
Implements a separator offset to match the iOS7 tableview styling. Defaults to 0,0 so as to not interfere with existing uses. The example project shows an offset of 15 width.
