### PR TITLE
Adding a 'closeAnimationDuration'

### DIFF
--- a/REMenu/REMenu.h
+++ b/REMenu/REMenu.h
@@ -94,6 +94,7 @@ typedef NS_ENUM(NSInteger, REMenuLiveBackgroundStyle) {
 @property (assign, readwrite, nonatomic) CGSize subtitleHighlightedTextShadowOffset;
 @property (assign, readwrite, nonatomic) NSTextAlignment subtitleTextAlignment;
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;
+@property (assign, readwrite, nonatomic) NSTimeInterval closeAnimationDuration;
 @property (assign, readwrite, nonatomic) NSTimeInterval bounceAnimationDuration;
 @property (assign, readwrite, nonatomic) BOOL appearsBehindNavigationBar;
 @property (assign, readwrite, nonatomic) BOOL bounce;

--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -90,6 +90,7 @@
         _borderWidth = 1.0;
         _borderColor =  [UIColor colorWithRed:28/255.0 green:28/255.0 blue:27/255.0 alpha:1.0];
         _animationDuration = 0.3;
+        _closeAnimationDuration = 0.2;
         _bounce = YES;
         _bounceAnimationDuration = 0.2;
         
@@ -315,7 +316,7 @@
     CGFloat navigationBarOffset = self.appearsBehindNavigationBar && self.navigationBar ? 64 : 0;
     
     void (^closeMenu)(void) = ^{
-        [UIView animateWithDuration:self.animationDuration
+        [UIView animateWithDuration:self.closeAnimationDuration
                               delay:0.0
                             options:UIViewAnimationOptionBeginFromCurrentState|UIViewAnimationOptionCurveEaseInOut
                          animations:^ {


### PR DESCRIPTION
Adding a `closeAnimationDuration` @property to `REMenu` (`animationDuration` now only affects the menu opening). Allows the open and close animations to vary independently, because I've found a more pleasing user experience to have the open be "slower" and the close be "faster". I've seen this in other UI elements, such as UIPopoverController.
