### PR TITLE
Adding a delegate to REMenu for handling before and after an open or clo...

### DIFF
--- a/REMenu/REMenu.h
+++ b/REMenu/REMenu.h
@@ -29,6 +29,7 @@
 #import "REMenuItem.h"
 #import "REMenuContainerView.h"
 
+@class REMenu;
 @class REMenuItem;
 
 typedef NS_ENUM(NSInteger, REMenuImageAlignment) {
@@ -40,6 +41,15 @@ typedef NS_ENUM(NSInteger, REMenuLiveBackgroundStyle) {
     REMenuLiveBackgroundStyleLight,
     REMenuLiveBackgroundStyleDark
 };
+
+@protocol REMenuDelegate <NSObject>
+@optional
+-(void)willOpenMenu:(REMenu *)menu;
+-(void)didOpenMenu:(REMenu *)menu;
+-(void)willCloseMenu:(REMenu *)menu;
+-(void)didCloseMenu:(REMenu *)menu;
+
+@end
 
 @interface REMenu : NSObject 
 
@@ -53,6 +63,7 @@ typedef NS_ENUM(NSInteger, REMenuLiveBackgroundStyle) {
 @property (copy, readwrite, nonatomic) void (^closeCompletionHandler)(void);
 @property (copy, readwrite, nonatomic) void (^closePreparationBlock)(void);
 @property (assign, readwrite, nonatomic) BOOL closeOnSelection;
+@property (weak, readwrite, nonatomic) id <REMenuDelegate> delegate;
 
 // Style
 //

--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -240,6 +240,10 @@
     [self.containerView addSubview:self.menuWrapperView];
     [view addSubview:self.containerView];
     
+    if ([self.delegate respondsToSelector:@selector(willOpenMenu:)]) {
+        [self.delegate willOpenMenu:self];
+    }
+    
     // Animate appearance
     //
     if (self.bounce) {
@@ -257,6 +261,9 @@
                  self.menuWrapperView.frame = frame;
              } completion:^(BOOL finished) {
                  self.isAnimating = NO;
+                 if ([self.delegate respondsToSelector:@selector(didOpenMenu:)]) {
+                     [self.delegate didOpenMenu:self];
+                 }
              }];
         } else {
             [UIView animateWithDuration:self.animationDuration
@@ -269,6 +276,9 @@
                  self.menuWrapperView.frame = frame;
              } completion:^(BOOL finished) {
                  self.isAnimating = NO;
+                 if ([self.delegate respondsToSelector:@selector(didOpenMenu:)]) {
+                     [self.delegate didOpenMenu:self];
+                 }
              }];
 
         }
@@ -283,6 +293,9 @@
             self.menuWrapperView.frame = frame;
         } completion:^(BOOL finished) {
             self.isAnimating = NO;
+            if ([self.delegate respondsToSelector:@selector(didOpenMenu:)]) {
+                [self.delegate didOpenMenu:self];
+            }
         }];
     }
 }
@@ -341,12 +354,18 @@
             if (self.closeCompletionHandler) {
                 self.closeCompletionHandler();
             }
+            if ([self.delegate respondsToSelector:@selector(didCloseMenu:)]) {
+                [self.delegate didCloseMenu:self];
+            }
         }];
         
     };
     
     if (self.closePreparationBlock) {
         self.closePreparationBlock();
+    }
+    if ([self.delegate respondsToSelector:@selector(willCloseMenu:)]) {
+        [self.delegate willCloseMenu:self];
     }
     
     if (self.bounce) {

--- a/REMenuExample/REMenuExample/Classes/Controllers/NavigationViewController.m
+++ b/REMenuExample/REMenuExample/Classes/Controllers/NavigationViewController.m
@@ -14,7 +14,7 @@
 #import "ActivityViewController.h"
 #import "ProfileViewController.h"
 
-@interface NavigationViewController ()
+@interface NavigationViewController () <REMenuDelegate>
 
 @property (strong, readwrite, nonatomic) REMenu *menu;
 
@@ -123,6 +123,7 @@
         badgeLabel.backgroundColor = [UIColor colorWithRed:0 green:179/255.0 blue:134/255.0 alpha:1];
         badgeLabel.layer.borderColor = [UIColor colorWithRed:0.000 green:0.648 blue:0.507 alpha:1.000].CGColor;
     };
+    self.menu.delegate = self;
     
     
     [self.menu setClosePreparationBlock:^{
@@ -141,6 +142,28 @@
         return [self.menu close];
     
     [self.menu showFromNavigationController:self];
+}
+
+#pragma mark - REMenu Delegate Methods
+
+-(void)willOpenMenu:(REMenu *)menu
+{
+    NSLog(@"Delegate method: %@", NSStringFromSelector(_cmd));
+}
+
+-(void)didOpenMenu:(REMenu *)menu
+{
+    NSLog(@"Delegate method: %@", NSStringFromSelector(_cmd));
+}
+
+-(void)willCloseMenu:(REMenu *)menu
+{
+    NSLog(@"Delegate method: %@", NSStringFromSelector(_cmd));
+}
+
+-(void)didCloseMenu:(REMenu *)menu
+{
+    NSLog(@"Delegate method: %@", NSStringFromSelector(_cmd));
 }
 
 @end


### PR DESCRIPTION
Adding a delegate to REMenu for handling before and after an open/close. I considered adding two new blocks instead but given the functionality, delegation seems more appropriate. If you want I can use blocks instead.
