### PR TITLE
Highlighted color of the menu item should stay as expected. The live blur effect set alpha to 0.5 which lead highlight color to be not consistent with the expected one.

### DIFF
--- a/REMenu/REMenuItemView.m
+++ b/REMenu/REMenuItemView.m
@@ -47,8 +47,6 @@
         _backgroundView = ({
             UIView *view = [[UIView alloc] initWithFrame:self.bounds];
             view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-            if (menu.liveBlur && REUIKitIsFlatMode())
-                view.alpha = 0.5f;
             view;
         });
         [self addSubview:_backgroundView];


### PR DESCRIPTION
Removing the 50% alpha set to the background view if the liveBlur is enabled. Should be customizable.
