### PR TITLE
Fix Orientation and statusbar change bugs

### DIFF
--- a/REMenu/REMenuContainerView.m
+++ b/REMenu/REMenuContainerView.m
@@ -26,24 +26,41 @@
 #import "REMenuContainerView.h"
 #import <QuartzCore/QuartzCore.h>
 
+#define IS_IPAD (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+#define IS_IPHONE (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone)
+#define IS_RETINA ([[UIScreen mainScreen] scale] >= 2.0)
+
+#define SCREEN_WIDTH ([[UIScreen mainScreen] bounds].size.width)
+#define SCREEN_HEIGHT ([[UIScreen mainScreen] bounds].size.height)
+#define SCREEN_MAX_LENGTH (MAX(SCREEN_WIDTH, SCREEN_HEIGHT))
+#define SCREEN_MIN_LENGTH (MIN(SCREEN_WIDTH, SCREEN_HEIGHT))
+
+#define IS_IPHONE_4_OR_LESS (IS_IPHONE && SCREEN_MAX_LENGTH < 568.0)
+#define IS_IPHONE_5 (IS_IPHONE && SCREEN_MAX_LENGTH == 568.0)
+#define IS_IPHONE_6 (IS_IPHONE && SCREEN_MAX_LENGTH == 667.0)
+#define IS_IPHONE_6P (IS_IPHONE && SCREEN_MAX_LENGTH == 736.0)
 @implementation REMenuContainerView
 
 - (void)layoutSubviews
 {
     [super layoutSubviews];
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    if(IS_IPHONE_6P || IS_IPAD)
+        NSLog(@"iii");
+    CGFloat landscapeOffset = (IS_IPAD || IS_IPHONE_6P) ? 44.0 : 32.0;
+    NSLog(@"landscapeoffset %f", landscapeOffset);
     
-    CGFloat landscapeOffset = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 32.0 : 44.0;
+    CGFloat navBarHeight = UIInterfaceOrientationIsPortrait(orientation) ? 44.0 : landscapeOffset;
     
     if (self.navigationBar && !self.appearsBehindNavigationBar) {
         CGRect frame = self.frame;
-        frame.origin.y = self.navigationBar.frame.origin.y + (UIDeviceOrientationIsPortrait(orientation) ? 44.0 : landscapeOffset);
+        frame.origin.y = self.navigationBar.frame.origin.y + navBarHeight;
         self.frame = frame;
     }
     
     if (self.appearsBehindNavigationBar) {
         CGRect frame = self.frame;
-        frame.origin.y = (UIDeviceOrientationIsPortrait(orientation) ? 44.0 : landscapeOffset) - 44;
+        frame.origin.y = navBarHeight - 44 - ([UIApplication sharedApplication].isStatusBarHidden ? 20 : 0);
         self.frame = frame;
     }
 }


### PR DESCRIPTION
This File change fixes cases where orientation changes and status bar appears/dissapers and the REMENU's y position is not calculated right. Especially on iphone6plus where the landscape navbar height is 44 instead of 32 unlike other iphones. Also most probably by mistake you have written "UIDeviceOrientationIsPortrait" instead of "UIInterfaceOrientationIsPortrait".
