### PR TITLE
Add a force close option to menu.

### DIFF
--- a/REMenu/REMenu.h
+++ b/REMenu/REMenu.h
@@ -121,5 +121,6 @@ typedef NS_ENUM(NSInteger, REMenuLiveBackgroundStyle) {
 - (void)setNeedsLayout;
 - (void)closeWithCompletion:(void (^)(void))completion;
 - (void)close;
+- (void)forceClose;
 
 @end

--- a/REMenu/REMenu.m
+++ b/REMenu/REMenu.m
@@ -386,6 +386,12 @@
     [self closeWithCompletion:nil];
 }
 
+- (void)forceClose
+{
+    self.isAnimating = NO;
+    [self closeWithCompletion:nil];
+}
+
 - (CGFloat)combinedHeight
 {
     return self.items.count * self.itemHeight + self.items.count * self.separatorHeight + 40.0 + self.cornerRadius;


### PR DESCRIPTION
Sometimes it is necessary to have a force close mechanism. I need this in this scenery: tap menu button and quickly press a button to push another view controller. without this mechanism the menu appears on another screen as well.
